### PR TITLE
chore: Setting to hide the Papirus icon theme for users

### DIFF
--- a/Papirus-Dark/index.theme
+++ b/Papirus-Dark/index.theme
@@ -2,6 +2,7 @@
 Name=Papirus-Dark
 Comment=Papirus icon theme for dark themes
 Inherits=breeze-dark,hicolor
+Hidden=true
 
 Example=folder
 

--- a/Papirus-Light/index.theme
+++ b/Papirus-Light/index.theme
@@ -2,6 +2,7 @@
 Name=Papirus-Light
 Comment=Papirus icon theme for bright themes
 Inherits=breeze,hicolor
+Hidden=true
 
 Example=folder
 

--- a/Papirus/index.theme
+++ b/Papirus/index.theme
@@ -2,6 +2,7 @@
 Name=Papirus
 Comment=Papirus icon theme
 Inherits=breeze,hicolor
+Hidden=true
 
 Example=folder
 

--- a/ePapirus-Dark/index.theme
+++ b/ePapirus-Dark/index.theme
@@ -2,6 +2,7 @@
 Name=ePapirus-Dark
 Comment=Papirus Dark icon theme for elementary OS
 Inherits=elementary,hicolor
+Hidden=true
 
 Example=folder
 

--- a/ePapirus/index.theme
+++ b/ePapirus/index.theme
@@ -2,6 +2,7 @@
 Name=ePapirus
 Comment=Papirus icon theme for elementary OS
 Inherits=elementary,hicolor
+Hidden=true
 
 Example=folder
 


### PR DESCRIPTION
Setting to hide the Papirus icon theme for users

Issue: https://github.com/linuxdeepin/developer-center/issues/9024